### PR TITLE
Always use dark theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base="dark"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,4 +4,3 @@ python-dotenv
 motor[srv]
 beanie
 uvicorn
-st-theme

--- a/frontend/plots.py
+++ b/frontend/plots.py
@@ -6,7 +6,6 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
-from streamlit_theme import st_theme
 
 from .models import CocktailSchema, InstallationSchema
 
@@ -49,9 +48,6 @@ def generate_volume_treemap(df: pd.DataFrame, country_split: bool = True):
     if country_split:
         path = [px.Constant("Language used"), CocktailSchema.language, CocktailSchema.machine_name]
 
-    theme = st_theme()
-    background_color = theme["backgroundColor"] if theme else "#0E1117"
-
     fig = px.treemap(
         df,
         path=path,
@@ -59,7 +55,7 @@ def generate_volume_treemap(df: pd.DataFrame, country_split: bool = True):
         height=_TREEMAP_HEIGHT,
         hover_data=[CocktailSchema.cocktail_count],
         color=CocktailSchema.machine_name,
-        color_discrete_sequence=[background_color],  # will set bg color of the constant
+        color_discrete_sequence=["#0E1117"],  # will set bg color of the constant
         color_discrete_map=_get_machine_color_map(df),
     )
     fig.update_layout({"margin": {"l": 0, "r": 0, "t": 0, "b": 0}})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "plotly>=6.0.1",
     "python-dotenv>=1.1.0",
     "requests>=2.32.3",
-    "st-theme>=1.2.3",
     "streamlit>=1.44.1",
     "uvicorn>=0.34.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,6 @@ dependencies = [
     { name = "plotly" },
     { name = "python-dotenv" },
     { name = "requests" },
-    { name = "st-theme" },
     { name = "streamlit" },
     { name = "uvicorn" },
 ]
@@ -334,7 +333,6 @@ requires-dist = [
     { name = "plotly", specifier = ">=6.0.1" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "requests", specifier = ">=2.32.3" },
-    { name = "st-theme", specifier = ">=1.2.3" },
     { name = "streamlit", specifier = ">=1.44.1" },
     { name = "uvicorn", specifier = ">=0.34.2" },
 ]
@@ -1764,18 +1762,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/95/81babb6089938680dfe2cd3f88cd3fd39cccd1543b7cb603b21ad881bff1/SQLAlchemy-2.0.36-cp313-cp313-win32.whl", hash = "sha256:0572f4bd6f94752167adfd7c1bed84f4b240ee6203a95e05d1e208d488d0d436", size = 2060439 },
     { url = "https://files.pythonhosted.org/packages/c1/ce/5f7428df55660d6879d0522adc73a3364970b5ef33ec17fa125c5dbcac1d/SQLAlchemy-2.0.36-cp313-cp313-win_amd64.whl", hash = "sha256:8c78ac40bde930c60e0f78b3cd184c580f89456dd87fc08f9e3ee3ce8765ce88", size = 2084574 },
     { url = "https://files.pythonhosted.org/packages/b8/49/21633706dd6feb14cd3f7935fc00b60870ea057686035e1a99ae6d9d9d53/SQLAlchemy-2.0.36-py3-none-any.whl", hash = "sha256:fddbe92b4760c6f5d48162aef14824add991aeda8ddadb3c31d56eb15ca69f8e", size = 1883787 },
-]
-
-[[package]]
-name = "st-theme"
-version = "1.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "streamlit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/31/84/3e2fd95f5acaf6c92a51e7f038f1120235c65bb0b8be9bf43aa9fb4267e5/st-theme-1.2.3.tar.gz", hash = "sha256:ca97aece1a48ded6e83fd742c27cb0851e1bce2100ab4b6c37c7b6e003b65b42", size = 73873 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/09/cd7134f1ed5074a7d456640e7ba9a8c8e68a831837b4e7bfd9f29e5700a4/st_theme-1.2.3-py3-none-any.whl", hash = "sha256:0a54d9817dd5f8a6d7b0d071b25ae72eacf536c63a5fb97374923938021b1389", size = 75205 },
 ]
 
 [[package]]


### PR DESCRIPTION
It causes multiple rerenders when using the st-theme package which impact performance. Currently there is no proper way to read out the current theme when it is not explicitly set. Streamlit team seems to work on a feature which might fix this, but it is delayed. So we currently always do dark theme for now.